### PR TITLE
Improve contract validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dump.json
 report.html
 *.sqlite
 **/*.db

--- a/docs/WHAT_IS_NEW.md
+++ b/docs/WHAT_IS_NEW.md
@@ -1,4 +1,21 @@
 # What's New
+## 0.0.26
+This release improves the validation of transaction contracts (`requires` and `ensures`) to allow users to return truthy values in positive paths and falsy values in negative paths.
+
+```python
+class MyContract(AbstractTransaction):
+    def do(self, param):
+        return object() if param > 10 else None
+
+
+class MainTransaction(AbstractTransaction):
+    requires = [MyContract]
+
+    def do(self, param): ...
+```
+
+If the contract is violated then a `ContractError` exception is raised.
+
 ## 0.0.25
 
 This release introduces a major evolution of Guará's execution model, with new capabilities for **transaction control, execution policies, contracts, dry runs, execution history, replay, and application-level orchestration**.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = "Douglas Cardoso"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "0.0.25"
+release = "0.0.26"
 
 
 # -- General configuration ---------------------------------------------------

--- a/guara/constants.py
+++ b/guara/constants.py
@@ -10,7 +10,7 @@ from guara.utils import convert_variable_to_integer
 
 LOGGER: Logger = getLogger(__name__)
 
-VERSION = "0.0.25"
+VERSION = "0.0.26"
 GUARA_VERBOSE = getenv("GUARA_VERBOSE", "true").lower() == "true"
 GUARA_DISABLE_LOGS = getenv("GUARA_DISABLE_LOGS", "false").lower() == "true"
 GUARA_DRY_RUN = getenv("GUARA_DRY_RUN", "false").lower() == "true"

--- a/guara/transaction.py
+++ b/guara/transaction.py
@@ -49,6 +49,10 @@ class PosconditionError(Exception):
     """Raised when a pos-conditon cannot be executed."""
 
 
+class ContractError(Exception):
+    """Raised when contracts in transaction `requires` or `ensures` are violated."""
+
+
 def _get_module_path(transaction: AbstractTransaction) -> str:
     """Return the complete Python module path for a transaction."""
     file_path = Path(inspect.getfile(type(transaction))).resolve()
@@ -340,7 +344,10 @@ class Application:
         sig = inspect.signature(contract.do)
         valid_keys = sig.parameters.keys()
         filtered_k = {key: value for key, value in kwargs.items() if key in valid_keys}
-        Application(self._driver).execute(contract, **filtered_k)
+        if not Application(self._driver).execute(contract, **filtered_k).result:
+            raise ContractError(
+                f"Contract '{contract.__name__}' violated. Ensure it returns a truthy value for positive paths."
+            )
 
     def _create_transaction_execution(
         self,
@@ -570,6 +577,19 @@ class Application:
             (Application)
         """
         self._transaction = transaction(self._driver)
+
+        # Validate transaction parameters before execute it
+        try:
+            # Retrieve the expected function signature
+            sig = inspect.signature(self._transaction.do)
+            # .bind() throws a TypeError immediately if parameters don't match
+            bound_args = sig.bind(**kwargs)
+            # (Optional) Apply default values to the bound arguments dictionary
+            bound_args.apply_defaults()
+        except TypeError as e:
+            raise TypeError(
+                f"Transaction '{self._transaction.__name__}' failed ({e!s})"
+            )
 
         self._dry_run = (
             self._transaction.execution_policy.dry_run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ exclude = ["examples*", ".vscode", ".git*", "dist*", "*pytest*", "docs*"]
 
 [project]
 name = "guara"
-version = "0.0.25"
+version = "0.0.26"
 authors = [
   { name="Douglas Cardoso", email="29078346+douglasdcm@users.noreply.github.com" },
 ]

--- a/tests/unit_test/test_transaction_contract.py
+++ b/tests/unit_test/test_transaction_contract.py
@@ -10,7 +10,7 @@ from pytest import raises
 
 from guara import it
 from guara.policy import ApplicationPolicy, TransactionPolicy
-from guara.transaction import AbstractTransaction, Application
+from guara.transaction import AbstractTransaction, Application, ContractError
 
 
 class Error(Exception):
@@ -27,23 +27,27 @@ class IsUserLoggedIn(AbstractTransaction):
     def do(self, r: Repository):
         if not r.loggedin:
             raise Error("not logged in")
+        return True
 
 
 class IsManager(AbstractTransaction):
     def do(self, r: Repository):
         if not r.manager:
             Error("not manager")
+        return True
 
 
 class AreValidValuesToRegistreProduct(AbstractTransaction):
     def do(self, minimum_stock, r):
         assert minimum_stock is not None
+        return True
 
 
 class HasNotRegistredProduct(AbstractTransaction):
     def do(self, r: Repository):
         if r.product:
             raise Error("product already exist")
+        return True
 
 
 class ProductExists(AbstractTransaction):
@@ -51,6 +55,7 @@ class ProductExists(AbstractTransaction):
         assert name is not None
         if not r.product:
             raise Error("product not exist")
+        return object()
 
 
 class CreateProduct(AbstractTransaction):
@@ -189,3 +194,81 @@ def test_application_do_not_run_ensures_and_requires_when_dry_run():
         .then(it.IsEqualTo, "anything")
         .undo()
     )
+
+
+class ContractWithNoParameter(AbstractTransaction):
+    def do(self, param1):
+        return param1 == "foo"
+
+
+class MainTransaction(AbstractTransaction):
+    requires: ClassVar = [ContractWithNoParameter]
+
+    def do(self, param1, param2, **kwrags):
+        return True
+
+
+def test_contract_ignores_exceeding_parameters():
+    app = Application()
+    (app.execute(MainTransaction, param1="foo", param2="bla", extra_param="nay"))
+
+
+def test_contract_ignores_exceeding_parameters_and_raise_exception():
+    with raises(ContractError):
+        app = Application()
+        (app.execute(MainTransaction, param1="jojo", param2="bla", extra_param="nay"))
+
+
+class ContractWithParameter(AbstractTransaction):
+    def do(self, param10, param11, param12):
+        return True
+
+
+class MyMainTransactionWithoutParams(AbstractTransaction):
+    requires: ClassVar = [ContractWithParameter]
+
+    def do(self):
+        return True
+
+
+def test_contract_complains_about_missing_parameter():
+    with raises(TypeError):
+        app = Application()
+        (app.execute(MyMainTransactionWithoutParams))
+
+
+class MainTransactionWithKwargs(AbstractTransaction):
+    requires: ClassVar = [ContractWithParameter]
+
+    def do(self, **kwargs):
+        return True
+
+
+def test_contract_complains_about_kwargs_in_main_transaction():
+    with raises(TypeError):
+        app = Application()
+        (app.execute(MainTransactionWithKwargs, foo="foo", bla="bla", jo="jo"))
+
+
+def test_contract_works_when_kwargs_sent_in_main_transaction():
+    app = Application()
+    (app.execute(MainTransactionWithKwargs, param10="foo", param11="bla", param12="jo"))
+
+
+def test_transaction_with_kwargs_compains_when_missing_paramter_shared_by_contracts():
+    with raises(TypeError):
+        app = Application()
+        (app.execute(MainTransactionWithKwargs, param10="foo", param11="bla"))
+
+
+class MainTransactionWithNamedParams(AbstractTransaction):
+    requires: ClassVar = [ContractWithParameter]
+
+    def do(self, parama, paramb, paramc):
+        return True
+
+
+def test_transaction_with_named_params_compains_when_missing_paramter_shared_by_contracts():
+    with raises(TypeError):
+        app = Application()
+        (app.execute(MainTransactionWithNamedParams, parama="foo", paramb="bla"))


### PR DESCRIPTION
This release improves the validation of transaction contracts (`requires` and `ensures`) to allow users to return truthy values in positive paths and falsy values in negative paths.

```python
class MyContract(AbstractTransaction):
    def do(self, param):
        return object() if param > 10 else None


class MainTransaction(AbstractTransaction):
    requires = [MyContract]

    def do(self, param): ...
```

If the contract is violated then a `ContractError` exception is raised.